### PR TITLE
STP-2 Fix sanitization of indices

### DIFF
--- a/common.cc
+++ b/common.cc
@@ -2,6 +2,22 @@
 
 #include <gtest/gtest.h>
 
+TEST(Common, SanitizeIndex)
+{
+    int index = -1;
+    EXPECT_EQ(23, Text::sanitize_index(index, 24));
+}
+
+TEST(Common, SanitizeRValueIndex)
+{
+    EXPECT_EQ(0, Text::sanitize_index(-24, 24));
+    EXPECT_EQ(23, Text::sanitize_index(-1, 24));
+    EXPECT_EQ(1, Text::sanitize_index(1, 24));
+    EXPECT_EQ(23, Text::sanitize_index(23, 24));
+    EXPECT_EQ(24, Text::sanitize_index(24, 24));
+    EXPECT_EQ(Text::End, Text::sanitize_index(25, 24));
+}
+
 TEST(Common, IntViewToVector)
 {
     std::basic_string<int> data{1, 2, 3, 1, 1, 2, 3, 1, 4, 1};

--- a/count.cc
+++ b/count.cc
@@ -18,6 +18,32 @@ TEST(Count, SimpleWithViewAndLongerNeedle)
     EXPECT_EQ(result, 2);
 }
 
+TEST(Count, SimpleWithCustomTypeWord)
+{
+    struct MyType
+    {
+        int val;
+        bool operator==(const MyType&) const = default;
+    };
+
+    std::vector<MyType> simple{{0}, {1337}, {12}};
+    auto result = Text::count(simple, std::vector<MyType>{{1337}, {12}});
+    EXPECT_EQ(result, 1);
+}
+
+TEST(Count, SimpleWithCustomTypeChar)
+{
+    struct MyType
+    {
+        int val;
+        bool operator==(const MyType&) const = default;
+    };
+
+    std::vector<MyType> simple{{0}, {1337}};
+    auto result = Text::count(simple, MyType{1337});
+    EXPECT_EQ(result, 1);
+}
+
 TEST(CountIf, LargerThanValue)
 {
     using namespace std::literals;
@@ -31,5 +57,38 @@ TEST(CountAny, SimpleWithView)
     using namespace std::literals;
     auto simple_sv = "simple string with words"sv;
     auto result = Text::count_any(simple_sv, "tg");
+    EXPECT_EQ(result, 3);
+}
+
+TEST(CountAny, SimpleWithCustomType)
+{
+    struct MyType
+    {
+        int val;
+        bool operator<(const MyType& arg) const
+        {
+            return val < arg.val;
+        }
+    };
+
+    std::vector<MyType> simple{{0}, {1}, {2}, {1337}};
+    std::vector<MyType> delimiters{{0}, {1}, {3}, {1337}};
+    auto result = Text::count_any(simple, delimiters);
+    EXPECT_EQ(result, 3);
+}
+
+TEST(Count, SimpleTestBoundsImplicit)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple string with words"sv;
+    auto result = Text::count(simple_sv, "s");
+    EXPECT_EQ(result, 3);
+}
+
+TEST(Count, SimpleTestBoundsExplicit)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple string with words"sv;
+    auto result = Text::count(simple_sv, "s", Text::Start, Text::End);
     EXPECT_EQ(result, 3);
 }

--- a/find.cc
+++ b/find.cc
@@ -15,7 +15,7 @@ TEST(Find, SimpleWithViewEmptyNeedle)
     using namespace std::literals;
     std::string simple("simple string with words");
     auto result = Text::find(simple, ""sv);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(Find, SimpleWithOutOfBoundsStart)
@@ -23,15 +23,15 @@ TEST(Find, SimpleWithOutOfBoundsStart)
     using namespace std::literals;
     std::string simple("simple string with words");
     auto result = Text::find(simple, " "sv, 100);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(Find, ZeroStep)
 {
     using namespace std::literals;
     std::string simple("simple string with words");
-    auto result = Text::find(simple, " "sv, 0, 0);
-    EXPECT_EQ(result, Text::npos);
+    auto result = Text::find(simple, " "sv, Text::Start, Text::End, 0);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(Find, SimpleWithUint8String)
@@ -108,7 +108,7 @@ TEST(Find, SimpleNotFoundWithView)
     using namespace std::literals;
     std::string simple("simple string with words");
     auto result = Text::find(simple, "x"sv);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(Find, SimpleWithViewAndStart)
@@ -134,7 +134,7 @@ TEST(Find, MultipleWithView)
         start = result + 1;
     }
     result = Text::find(simple, needle, start);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(Find, SimpleWithLongerView)
@@ -150,7 +150,7 @@ TEST(Find, ViewLongerThanContainer)
     using namespace std::literals;
     std::string simple("simple string with words");
     auto result = Text::find(simple, "simple string with words "sv);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(Find, ViewWithNegativeStart)
@@ -165,7 +165,7 @@ TEST(Find, ViewWithStep)
 {
     using namespace std::literals;
     std::string simple("simple string with words");
-    auto result = Text::find(simple, " "sv, 1, 2);
+    auto result = Text::find(simple, " "sv, 1, Text::End, 2);
     EXPECT_EQ(result, 13);
 }
 
@@ -174,7 +174,7 @@ TEST(Find, ViewNotFound)
     using namespace std::literals;
     std::string simple("simple string with words");
     auto result = Text::find(simple, "strings"sv);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(FindIf, View)
@@ -191,7 +191,7 @@ TEST(FindIf, OutOfBoundsStart)
     std::string_view simple("simple string with words");
     auto result = Text::find_if(
         simple, [](auto ch) { return ch > 'u'; }, 100);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(FindIf, ZeroStep)
@@ -199,8 +199,8 @@ TEST(FindIf, ZeroStep)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::find_if(
-        simple, [](auto ch) { return ch > 'u'; }, 0, 0);
-    EXPECT_EQ(result, Text::npos);
+        simple, [](auto ch) { return ch > 'u'; }, Text::Start, Text::End, 0);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(FindIf, WideView)
@@ -233,7 +233,7 @@ TEST(RFind, SimpleWithOutOfBoundsStart)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::rfind(simple, " "sv, 100);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(RFind, ZeroStep)
@@ -241,7 +241,7 @@ TEST(RFind, ZeroStep)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::rfind(simple, " "sv, 0, 0);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(RFindIf, ZeroStep)
@@ -250,22 +250,22 @@ TEST(RFindIf, ZeroStep)
     std::string_view simple("simple string with words");
     auto result = Text::rfind_if(
         simple, [](auto ch) { return ch > 'u'; }, 0, 0);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
-TEST(RFind, ViewWithNegativeStart)
+TEST(RFind, ViewWithNegativeEnd)
 {
     using namespace std::literals;
     std::string_view simple("simple string with words");
-    auto result = Text::rfind(simple, " "sv, -8);
-    EXPECT_EQ(result, 6);
+    auto result = Text::rfind(simple, " "sv, Text::Start, -8);
+    EXPECT_EQ(result, 13);
 }
 
 TEST(RFind, ViewWithStep)
 {
     using namespace std::literals;
     std::string_view simple("simple string with words");
-    auto result = Text::rfind(simple, " "sv, 2, 2);
+    auto result = Text::rfind(simple, " "sv, Text::Start, Text::End, 2);
     EXPECT_EQ(result, 13);
 }
 
@@ -274,7 +274,7 @@ TEST(RFind, SimpleWithViewAndStart)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::rfind(simple, " "sv, 7);
-    EXPECT_EQ(result, 13);
+    EXPECT_EQ(result, 18);
 }
 
 TEST(RFindIf, View)
@@ -291,7 +291,7 @@ TEST(RFindIf, OutOfBoundsStart)
     std::string_view simple("simple string with words");
     auto result = Text::rfind_if(
         simple, [](auto ch) { return ch > 'u'; }, 100);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(RFindIf, ViewWithStart)
@@ -316,15 +316,15 @@ TEST(FindAny, OutOfBoundsStart)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::find_any(simple, "tg"sv, 100);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(FindAny, ZeroStep)
 {
     using namespace std::literals;
     std::string_view simple("simple string with words");
-    auto result = Text::find_any(simple, "tg"sv, 0, 0);
-    EXPECT_EQ(result, Text::npos);
+    auto result = Text::find_any(simple, "tg"sv, Text::Start, Text::End, 0);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(FindAny, SimpleWithString)
@@ -358,7 +358,7 @@ TEST(FindAny, MultipleWithView)
         start = result + 1;
     }
     result = Text::find_any(simple, needle, start);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(FindAny, ViewWithNegativeStart)
@@ -390,7 +390,7 @@ TEST(RFindAny, OutOfBoundsStart)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::rfind_any(simple, "tg"sv, 100);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(RFindAny, ZeroStep)
@@ -398,7 +398,7 @@ TEST(RFindAny, ZeroStep)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::rfind_any(simple, "tg"sv, 0, 0);
-    EXPECT_EQ(result, Text::npos);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(RFindAny, SimpleWithString)
@@ -421,18 +421,18 @@ TEST(RFindAny, MultipleWithView)
 {
     using namespace std::literals;
     std::string_view simple("simple string with words");
-    auto start = simple.length();
+    auto end = simple.length();
     auto result = 0;
     std::vector<int> expected{16, 12, 8};
     auto needle = "tg"sv;
     for (const auto exp : expected)
     {
-        result = Text::rfind_any(simple, needle, simple.length() - start);
+        result = Text::rfind_any(simple, needle, Text::Start, end);
         EXPECT_EQ(result, exp);
-        start = result - 1;
+        end = result - 1;
     }
-    result = Text::rfind_any(simple, needle, simple.length() - start);
-    EXPECT_EQ(result, Text::npos);
+    result = Text::rfind_any(simple, needle, Text::Start, end);
+    EXPECT_EQ(result, Text::End);
 }
 
 TEST(RFindAny, ViewWithNegativeStart)
@@ -440,5 +440,5 @@ TEST(RFindAny, ViewWithNegativeStart)
     using namespace std::literals;
     std::string_view simple("simple string with words");
     auto result = Text::rfind_any(simple, "tg"sv, -12);
-    EXPECT_EQ(result, 8);
+    EXPECT_EQ(result, 16);
 }

--- a/include/text_processing/common.hpp
+++ b/include/text_processing/common.hpp
@@ -56,8 +56,9 @@ template <typename T>
 using container_type_t = typename detail::container_type<T>::value_type;
 
 namespace Text {
-constexpr int npos = -1;
-constexpr int def_length = std::numeric_limits<int>::max();
+constexpr int Start = 0;
+constexpr int End = std::numeric_limits<int>::max();
+constexpr int Step = 1;
 
 template <typename T>
 auto to_vector(const std::basic_string_view<T>& container)
@@ -111,13 +112,16 @@ constexpr T clamp(T value, T low_value, T high_value)
     return value;
 }
 
-template <typename T>
-constexpr T sanitize_index(T& index, size_t text_size)
+template <typename T, typename Value = std::remove_cvref_t<T>>
+constexpr Value sanitize_index(T&& index, size_t text_size)
 {
-    if (index < T{0})
-        index = index + static_cast<T>(text_size);
-    if (text_size == 0 || index != clamp(index, T{0}, static_cast<T>(text_size - 1)))
-        return npos;
+    if (index < Value{0})
+        index = index + static_cast<Value>(text_size);
+    else if (index == Text::End)
+        index = text_size;
+
+    if (text_size == 0 || index != clamp(index, Value{0}, static_cast<Value>(text_size)))
+        return Text::End;
     return index;
 }
 

--- a/include/text_processing/count.hpp
+++ b/include/text_processing/count.hpp
@@ -7,32 +7,32 @@
 namespace Text {
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int count(const TextSrc& t, const NeedleSrc& n, int start = 0, int end = -1)
+int count(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End)
 {
     int cnt = 0;
     --start;
-    while((start = find(left_view(t, end), n, start + 1)) != npos)
+    while((start = find(left_view(t, end), n, start + 1)) != End)
         ++cnt;
     return cnt;
 }
 
 template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
-int count_if(const TextSrc& t, Predicate pred, int start = 0, int end = -1)
+int count_if(const TextSrc& t, Predicate pred, int start = Start, int end = End)
 {
     int cnt = 0;
     --start;
-    while((start = find_if(left_view(t, end), pred, start + 1)) != npos)
+    while((start = find_if(left_view(t, end), pred, start + 1)) != End)
         ++cnt;
     return cnt;
 }
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int count_any(const TextSrc& t, const NeedleSrc& d, int start = 0, int end = -1)
+int count_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End)
 {
     int cnt = 0;
     --start;
-    while((start = find_any(left_view(t, end), d, start + 1)) != npos)
+    while((start = find_any(left_view(t, end), d, start + 1)) != End)
         ++cnt;
     return cnt;
 }

--- a/include/text_processing/find.hpp
+++ b/include/text_processing/find.hpp
@@ -4,21 +4,24 @@
 
 namespace Text {
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0> requires std::equality_comparable<TextT>
-int find_impl(const TextSrc& t, const NeedleSrc& n, int start = 0, int step = 1)
+          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
+    requires std::equality_comparable<TextT>
+int find_impl(const TextSrc& t, const NeedleSrc& n, int start, int end, int step)
 {
     if (step == 0)
-        return npos;
+        return End;
 
     Text text(t);
     Delimiter needle(n);
 
     if (needle.length == 0)
-        return npos;
+        return End;
 
-    auto current = text.ptr + start;
+    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
+        return End;
 
-    while (current + needle.length <= text.ptr + text.length && current >= text.ptr)
+    auto current = step < 0 ? text.ptr + end - needle.length : text.ptr + start;
+    while (current + needle.length <= text.ptr + end && current >= text.ptr)
     {
         if (!are_equal(current, needle.ptr, needle.length))
         {
@@ -27,41 +30,35 @@ int find_impl(const TextSrc& t, const NeedleSrc& n, int start = 0, int step = 1)
         }
         return static_cast<int>(current - text.ptr);
     }
-    return npos;
+    return End;
 }
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int find(const TextSrc& t, const NeedleSrc& n, int start = 0, int step = 1)
+int find(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step)
 {
-    Text text(t);
-    if (sanitize_index(start, text.length) == npos)
-        return npos;
-    return find_impl(t, n, start, step);
+    return find_impl(t, n, start, end, step);
 }
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int rfind(const TextSrc& t, const NeedleSrc& n, int start = 0, int step = 1)
+int rfind(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step)
 {
-    Text text(t);
-    Delimiter needle(n);
-    if (sanitize_index(start, text.length) == npos)
-        return npos;
-    start = std::max(start, static_cast<int>(needle.length - 1));
-    return find_impl(t, n, static_cast<int>(text.length - start - 1), -step);
+    return find_impl(t, n, start, end, -step);
 }
 
 template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
-int find_if_impl(const TextSrc& t, Predicate pred, int start = 0, int step = 1)
+int find_if_impl(const TextSrc& t, Predicate pred, int start, int end, int step)
 {
     if (step == 0)
-        return npos;
+        return End;
 
     Text text(t);
 
-    auto current = text.ptr + start;
+    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
+        return End;
 
+    auto current = step < 0 ? text.ptr + end - 1 : text.ptr + start;
     while (current < text.ptr + text.length && current >= text.ptr)
     {
         if (!pred(*current))
@@ -71,39 +68,35 @@ int find_if_impl(const TextSrc& t, Predicate pred, int start = 0, int step = 1)
         }
         return static_cast<int>(current - text.ptr);
     }
-    return npos;
+    return End;
 }
 
 template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
-int find_if(const TextSrc& t, Predicate pred, int start = 0, int step = 1)
+int find_if(const TextSrc& t, Predicate pred, int start = Start, int end = End, int step = Step)
 {
-    Text text(t);
-    if (sanitize_index(start, text.length) == npos)
-        return npos;
-    return find_if_impl(t, pred, start, step);
+    return find_if_impl(t, pred, start, end, step);
 }
 
 template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
-int rfind_if(const TextSrc& t, Predicate pred, int start = 0, int step = 1)
+int rfind_if(const TextSrc& t, Predicate pred, int start = Start, int end = End, int step = Step)
 {
-    Text text(t);
-    if (sanitize_index(start, text.length) == npos)
-        return npos;
-    return find_if_impl(t, pred, static_cast<int>(text.length - start - 1), -step);
+    return find_if_impl(t, pred, start, end, -step);
 }
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int find_any_impl(const TextSrc& t, const NeedleSrc& d, int start = 0, int step = 1)
+int find_any_impl(const TextSrc& t, const NeedleSrc& d, int start, int end, int step)
 {
     if (step == 0)
-        return npos;
+        return End;
 
     Text text(t);
     Delimiters delimiters(d);
 
-    auto current = text.ptr + start;
+    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
+        return End;
 
+    auto current = step < 0 ? text.ptr + end - 1 : text.ptr + start;
     while (current < text.ptr + text.length && current >= text.ptr)
     {
         if (!delimiters.contains(*current))
@@ -113,27 +106,21 @@ int find_any_impl(const TextSrc& t, const NeedleSrc& d, int start = 0, int step 
         }
         return static_cast<int>(current - text.ptr);
     }
-    return npos;
+    return End;
 }
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int find_any(const TextSrc& t, const NeedleSrc& d, int start = 0, int step = 1)
+int find_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step)
 {
-    Text text(t);
-    if (sanitize_index(start, text.length) == npos)
-        return npos;
-    return find_any_impl(t, d, start, step);
+    return find_any_impl(t, d, start, end, step);
 }
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int rfind_any(const TextSrc& t, const NeedleSrc& d, int start = 0, int step = 1)
+int rfind_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step)
 {
-    Text text(t);
-    if (sanitize_index(start, text.length) == npos)
-        return npos;
-    return find_any_impl(t, d, static_cast<int>(text.length - start - 1), -step);
+    return find_any_impl(t, d, start, end, -step);
 }
 
 } // namespace Text

--- a/include/text_processing/remove.hpp
+++ b/include/text_processing/remove.hpp
@@ -14,10 +14,10 @@ struct RemoveResult
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-auto remove_impl(const TextSrc& t, const NeedleSrc& n, int start = 0, int end = -1) -> RemoveResult<TextT>
+auto remove_impl(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End) -> RemoveResult<TextT>
 {
     Text txt(t);
-    if (sanitize_index(start, txt.length) == npos || sanitize_index(end, txt.length) == npos)
+    if (sanitize_index(start, txt.length) == End || sanitize_index(end, txt.length) == End)
         return {std::basic_string(t)};
     auto splitted = split(t, n, SplitBehavior::KeepEmpty, start, end);
     return {join(splitted, std::basic_string_view<TextT>{}), static_cast<int>(splitted.size()) - 1};
@@ -56,10 +56,10 @@ template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_
 }
 
 template <typename TextSrc, typename TextT = container_type_t<TextSrc>, typename Predicate>
-auto remove_if_impl(const TextSrc& t, Predicate pred, int start = 0, int end = -1) -> RemoveResult<TextT>
+auto remove_if_impl(const TextSrc& t, Predicate pred, int start = Start, int end = End) -> RemoveResult<TextT>
 {
     Text txt(t);
-    if (sanitize_index(start, txt.length) == npos || sanitize_index(end, txt.length) == npos)
+    if (sanitize_index(start, txt.length) == End || sanitize_index(end, txt.length) == End)
         return {std::basic_string(t)};
     auto splitted = split_if(t, pred, SplitBehavior::KeepEmpty, start, end);
     return {join(splitted, std::basic_string_view<TextT>{}), static_cast<int>(splitted.size()) - 1};
@@ -95,10 +95,10 @@ template <typename TextSrc, typename TextT = container_type_t<TextSrc>, typename
 
 template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-auto remove_any_impl(const TextSrc& t, const NeedleSrc& d, int start = 0, int end = -1) -> RemoveResult<TextT>
+auto remove_any_impl(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End) -> RemoveResult<TextT>
 {
     Text txt(t);
-    if (sanitize_index(start, txt.length) == npos || sanitize_index(end, txt.length) == npos)
+    if (sanitize_index(start, txt.length) == End || sanitize_index(end, txt.length) == End)
         return {std::basic_string(t)};
     auto splitted = split_any(t, d, SplitBehavior::KeepEmpty, start, end);
     return {join(splitted, std::basic_string_view<TextT>{}), static_cast<int>(splitted.size()) - 1};

--- a/include/text_processing/replace.hpp
+++ b/include/text_processing/replace.hpp
@@ -17,10 +17,10 @@ struct ReplaceResult
 template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
           std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replace_impl(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start = 0, int end = -1)
+auto replace_impl(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End)
     -> ReplaceResult<TextT>
 {
-    if (sanitize_index(start, t.length()) == npos || sanitize_index(end, t.length()) == npos)
+    if (sanitize_index(start, t.length()) == End || sanitize_index(end, t.length()) == End)
         return {std::basic_string(t)};
     auto splitted = split(t, n, SplitBehavior::KeepEmpty, start, end);
     return {join(splitted, r), static_cast<int>(splitted.size()) - 1};
@@ -29,7 +29,7 @@ auto replace_impl(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int
 template <typename TextT, typename NeedleSrc, typename ReplaceSrc, typename NeedleT = container_type_t<NeedleSrc>,
           typename ReplaceT = container_type_t<ReplaceSrc>,
           std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-int replace(std::basic_string<TextT>& t, const NeedleSrc& n, const ReplaceSrc& r, int start = 0, int end = -1)
+int replace(std::basic_string<TextT>& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End)
 {
     auto result = replace_impl(t, n, r, start, end);
     t = std::move(result.text);
@@ -39,7 +39,7 @@ int replace(std::basic_string<TextT>& t, const NeedleSrc& n, const ReplaceSrc& r
 template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
           std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replaced(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start = 0, int end = -1)
+auto replaced(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End)
     -> std::basic_string<TextT>
 {
     return replace_impl(t, n, r, start, end).text;
@@ -47,10 +47,10 @@ auto replaced(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int sta
 
 template <typename TextSrc, typename Predicate, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
           typename ReplaceT = container_type_t<ReplaceSrc>, std::enable_if_t<std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replace_if_impl(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start = 0, int end = -1)
+auto replace_if_impl(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End)
     -> ReplaceResult<TextT>
 {
-    if (sanitize_index(start, t.length()) == npos || sanitize_index(end, t.length()) == npos)
+    if (sanitize_index(start, t.length()) == End || sanitize_index(end, t.length()) == End)
         return {std::basic_string(t)};
     auto splitted = split_if(t, pred, SplitBehavior::KeepEmpty, start, end);
     return {join(splitted, r), static_cast<int>(splitted.size()) - 1};
@@ -58,7 +58,7 @@ auto replace_if_impl(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int 
 
 template <typename TextT, typename Predicate, typename ReplaceSrc, typename ReplaceT = container_type_t<ReplaceSrc>,
           std::enable_if_t<std::is_same_v<TextT, ReplaceT>, int> = 0>
-int replace_if(std::basic_string<TextT>& t, Predicate pred, const ReplaceSrc& r, int start = 0, int end = -1)
+int replace_if(std::basic_string<TextT>& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End)
 {
     auto result = replace_if_impl(t, pred, r, start, end);
     t = std::move(result.text);
@@ -67,7 +67,7 @@ int replace_if(std::basic_string<TextT>& t, Predicate pred, const ReplaceSrc& r,
 
 template <typename TextSrc, typename Predicate, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
           typename ReplaceT = container_type_t<ReplaceSrc>, std::enable_if_t<std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replaced_if(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start = 0, int end = -1)
+auto replaced_if(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End)
     -> std::basic_string<TextT>
 {
     return replace_if_impl(t, pred, r, start, end).text;
@@ -76,10 +76,10 @@ auto replaced_if(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int star
 template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
           std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replace_any_impl(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start = 0, int end = -1)
+auto replace_any_impl(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start, int end = End)
     -> ReplaceResult<TextT>
 {
-    if (sanitize_index(start, t.length()) == npos || sanitize_index(end, t.length()) == npos)
+    if (sanitize_index(start, t.length()) == End || sanitize_index(end, t.length()) == End)
         return {std::basic_string(t)};
     auto splitted = split_any(t, d, SplitBehavior::KeepEmpty, start, end);
     return {join(splitted, r), static_cast<int>(splitted.size()) - 1};
@@ -88,7 +88,7 @@ auto replace_any_impl(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r,
 template <typename TextT, typename NeedleSrc, typename ReplaceSrc, typename NeedleT = container_type_t<NeedleSrc>,
           typename ReplaceT = container_type_t<ReplaceSrc>,
           std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-int replace_any(std::basic_string<TextT>& t, const NeedleSrc& d, const ReplaceSrc& r, int start = 0, int end = -1)
+int replace_any(std::basic_string<TextT>& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start, int end = End)
 {
     auto result = replace_any_impl(t, d, r, start, end);
     t = std::move(result.text);
@@ -98,7 +98,7 @@ int replace_any(std::basic_string<TextT>& t, const NeedleSrc& d, const ReplaceSr
 template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
           typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
           std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replaced_any(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start = 0, int end = -1)
+auto replaced_any(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start, int end = End)
     -> std::basic_string<TextT>
 {
     return replace_any_impl(t, d, r, start, end).text;

--- a/include/text_processing/split.hpp
+++ b/include/text_processing/split.hpp
@@ -30,7 +30,7 @@ auto split(const TextSrc& t, const DelimSrc& d, SplitBehavior beh = SplitBehavio
         return results;
     }
 
-    if (sanitize_index(start, text.length) == npos || sanitize_index(end, text.length) == npos)
+    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
     {
         results.emplace_back(text.ptr, text.length);
         return results;
@@ -68,7 +68,7 @@ auto split_any(const TextSrc& t, const DelimSrc& d, SplitBehavior beh = SplitBeh
     if (text.length == 0)
         return results;
 
-    if (sanitize_index(start, text.length) == npos || sanitize_index(end, text.length) == npos)
+    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
     {
         results.emplace_back(text.ptr, text.length);
         return results;
@@ -104,7 +104,7 @@ auto split_if(const TextSrc& t, Predicate pred, SplitBehavior beh = SplitBehavio
     if (text.length == 0)
         return results;
 
-    if (sanitize_index(start, text.length) == npos || sanitize_index(end, text.length) == npos)
+    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
     {
         results.emplace_back(text.ptr, text.length);
         return results;

--- a/include/text_processing/sub.hpp
+++ b/include/text_processing/sub.hpp
@@ -9,7 +9,7 @@ auto left_view(const T& text, int length)
 {
     Text t(text);
     length = std::min(static_cast<int>(t.length), length);
-    if (sanitize_index(length, t.length) == npos)
+    if (sanitize_index(length, t.length) == End)
         return std::basic_string_view<E>{};
     return std::basic_string_view<E>(t.ptr, static_cast<size_t>(length));
 }
@@ -25,7 +25,7 @@ auto right_view(const T& text, int length)
 {
     Text t(text);
     length = std::min(static_cast<int>(t.length), length);
-    if (sanitize_index(length, t.length) == npos)
+    if (sanitize_index(length, t.length) == End)
         return std::basic_string_view<E>{};
     return std::basic_string_view<E>(t.ptr + t.length - length, static_cast<size_t>(length));
 }
@@ -37,21 +37,21 @@ auto right(const T& text, int length)
 }
 
 template <typename T, typename E = container_type_t<T>>
-auto mid_view(const T& text, int start, int length = def_length)
+auto mid_view(const T& text, int start, int length = End)
 {
     Text t(text);
-    if (sanitize_index(start, t.length) == npos)
+    if (sanitize_index(start, t.length) == End)
         return std::basic_string_view<E>{};
 
     length = std::min(static_cast<int>(t.length) - start, length);
     auto end = length < 0 ? length - 1 : start + length - 1;
-    if (sanitize_index(end, t.length) == npos)
+    if (sanitize_index(end, t.length) == End)
         return std::basic_string_view<E>{};
     return std::basic_string_view<E>(t.ptr + start, static_cast<size_t>(end - start + 1));
 }
 
 template <typename T, typename E = container_type_t<T>>
-auto mid(const T& text, int start, int length = def_length)
+auto mid(const T& text, int start, int length = End)
 {
     return std::basic_string<E>(mid_view(text, start, length));
 }


### PR DESCRIPTION
* Indices can have values between 0 and size of view (included). Value equal to size of the view is out of boundary indicator.
* Special End value is equal to `std::numeric_limits<int>()` and is an easy way to indicate that any operation should be performed until boundary of a view is achieved. This does not require preliminary knowledge of a size of a container. Only drawback is that containers with size 2147483647 elements can not be handled correctly. However I think this is not an ussual case and it will be handled in the compile time to disallow of such usage (just to be safe)
* Index can be sanitize even if rvalue reference is passed.
* API has been changed as start/stop/step is more convenient way than start/step/stop (IMHO)