### PR TITLE
[STP-3] Add steps to algorithms, add case sensivity option

### DIFF
--- a/count.cc
+++ b/count.cc
@@ -44,12 +44,53 @@ TEST(Count, SimpleWithCustomTypeChar)
     EXPECT_EQ(result, 1);
 }
 
+TEST(Count, SimpleTestBoundsImplicit)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple string with words"sv;
+    auto result = Text::count(simple_sv, "s");
+    EXPECT_EQ(result, 3);
+}
+
+TEST(Count, SimpleTestBoundsExplicit)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple string with words"sv;
+    auto result = Text::count(simple_sv, "s", Text::Start, Text::End);
+    EXPECT_EQ(result, 3);
+}
+
+TEST(Count, CaseInsensitive)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple String with words"sv;
+    auto result = Text::count(simple_sv, "S", Text::Start, Text::End, Text::Step, Text::Case::Insensitive);
+    EXPECT_EQ(result, 3);
+}
+
+TEST(Count, WithSteps)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple string with words"sv;
+    auto result = Text::count(simple_sv, "s", Text::Start, Text::End, 2);
+    EXPECT_EQ(result, 1);
+}
+
 TEST(CountIf, LargerThanValue)
 {
     using namespace std::literals;
     auto simple_sv = "simple string with words"sv;
     auto result = Text::count_if(simple_sv, [](auto ch) { return ch > 'u'; });
     EXPECT_EQ(result, 2);
+}
+
+TEST(CountIf, WithSteps)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple string with words"sv;
+    auto result = Text::count_if(
+        simple_sv, [](auto ch) { return ch > 'u'; }, Text::Start, Text::End, 2);
+    EXPECT_EQ(result, 1);
 }
 
 TEST(CountAny, SimpleWithView)
@@ -65,10 +106,7 @@ TEST(CountAny, SimpleWithCustomType)
     struct MyType
     {
         int val;
-        bool operator<(const MyType& arg) const
-        {
-            return val < arg.val;
-        }
+        auto operator<=>(const MyType&) const = default;
     };
 
     std::vector<MyType> simple{{0}, {1}, {2}, {1337}};
@@ -77,18 +115,18 @@ TEST(CountAny, SimpleWithCustomType)
     EXPECT_EQ(result, 3);
 }
 
-TEST(Count, SimpleTestBoundsImplicit)
+TEST(CountAny, CaseInsensitive)
 {
     using namespace std::literals;
-    auto simple_sv = "simple string with words"sv;
-    auto result = Text::count(simple_sv, "s");
-    EXPECT_EQ(result, 3);
+    auto simple_sv = "simple String With words"sv;
+    auto result = Text::count_any(simple_sv, "Sw", Text::Start, Text::End, Text::Step, Text::Case::Insensitive);
+    EXPECT_EQ(result, 5);
 }
 
-TEST(Count, SimpleTestBoundsExplicit)
+TEST(CountAny, WithSteps)
 {
     using namespace std::literals;
     auto simple_sv = "simple string with words"sv;
-    auto result = Text::count(simple_sv, "s", Text::Start, Text::End);
-    EXPECT_EQ(result, 3);
+    auto result = Text::count_any(simple_sv, "sw", Text::Start, Text::End, 2);
+    EXPECT_EQ(result, 2);
 }

--- a/find.cc
+++ b/find.cc
@@ -177,6 +177,22 @@ TEST(Find, ViewNotFound)
     EXPECT_EQ(result, Text::End);
 }
 
+TEST(Find, CaseInsensitive)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple String with words"sv;
+    auto result = Text::find(simple_sv, "S", Text::Start, Text::End, Text::Step, Text::Case::Insensitive);
+    EXPECT_EQ(result, 0);
+}
+
+TEST(Find, WithSteps)
+{
+    using namespace std::literals;
+    auto simple_sv = "simple string with words"sv;
+    auto result = Text::find(simple_sv, "s", 1, Text::End, 2);
+    EXPECT_EQ(result, 7);
+}
+
 TEST(FindIf, View)
 {
     using namespace std::literals;
@@ -220,6 +236,15 @@ TEST(FindIf, ViewWithStart)
     EXPECT_EQ(result, 19);
 }
 
+TEST(FindIf, WithSteps)
+{
+    using namespace std::literals;
+    std::string_view simple("simple string with words");
+    auto result = Text::find_if(
+        simple, [](auto ch) { return ch > 'u'; }, 1, Text::End, 2);
+    EXPECT_EQ(result, 19);
+}
+
 TEST(RFind, SimpleWithView)
 {
     using namespace std::literals;
@@ -244,13 +269,12 @@ TEST(RFind, ZeroStep)
     EXPECT_EQ(result, Text::End);
 }
 
-TEST(RFindIf, ZeroStep)
+TEST(RFind, WithSteps)
 {
     using namespace std::literals;
     std::string_view simple("simple string with words");
-    auto result = Text::rfind_if(
-        simple, [](auto ch) { return ch > 'u'; }, 0, 0);
-    EXPECT_EQ(result, Text::End);
+    auto result = Text::rfind(simple, " "sv, Text::Start, Text::End, 2);
+    EXPECT_EQ(result, 13);
 }
 
 TEST(RFind, ViewWithNegativeEnd)
@@ -300,6 +324,24 @@ TEST(RFindIf, ViewWithStart)
     std::string_view simple("simple string with words");
     auto result = Text::find_if(
         simple, [](auto ch) { return ch > 'u'; }, 5);
+    EXPECT_EQ(result, 14);
+}
+
+TEST(RFindIf, ZeroStep)
+{
+    using namespace std::literals;
+    std::string_view simple("simple string with words");
+    auto result = Text::rfind_if(
+        simple, [](auto ch) { return ch > 'u'; }, 0, 0);
+    EXPECT_EQ(result, Text::End);
+}
+
+TEST(RFindIf, WithSteps)
+{
+    using namespace std::literals;
+    std::string_view simple("simple string with words");
+    auto result = Text::rfind_if(
+        simple, [](auto ch) { return ch > 'u'; }, Text::Start, -1, 2);
     EXPECT_EQ(result, 14);
 }
 
@@ -377,6 +419,14 @@ TEST(FindAny, WideView)
     EXPECT_EQ(result, 16);
 }
 
+TEST(FindAny, WithSteps)
+{
+    using namespace std::literals;
+    std::string_view simple("simple string with words");
+    auto result = Text::find_any(simple, "sw"sv, 1, Text::End, 2);
+    EXPECT_EQ(result, 7);
+}
+
 TEST(RFindAny, SimpleWithView)
 {
     using namespace std::literals;
@@ -421,7 +471,7 @@ TEST(RFindAny, MultipleWithView)
 {
     using namespace std::literals;
     std::string_view simple("simple string with words");
-    auto end = simple.length();
+    auto end = static_cast<int>(simple.length());
     auto result = 0;
     std::vector<int> expected{16, 12, 8};
     auto needle = "tg"sv;
@@ -441,4 +491,12 @@ TEST(RFindAny, ViewWithNegativeStart)
     std::string_view simple("simple string with words");
     auto result = Text::rfind_any(simple, "tg"sv, -12);
     EXPECT_EQ(result, 16);
+}
+
+TEST(RFindAny, WithSteps)
+{
+    using namespace std::literals;
+    std::string_view simple("simple string with words");
+    auto result = Text::rfind_any(simple, "sw"sv, Text::Start, -1, 2);
+    EXPECT_EQ(result, 14);
 }

--- a/include/text_processing/count.hpp
+++ b/include/text_processing/count.hpp
@@ -5,34 +5,36 @@
 #include "sub.hpp"
 
 namespace Text {
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int count(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+int count(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step,
+          Case sensitivity = Case::Sensitive)
 {
     int cnt = 0;
-    --start;
-    while((start = find(left_view(t, end), n, start + 1)) != End)
+    start -= step;
+    while ((start = find(t, n, start + step, end, step, sensitivity)) != End)
         ++cnt;
     return cnt;
 }
 
-template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
-int count_if(const TextSrc& t, Predicate pred, int start = Start, int end = End)
+template <typename TextSrc, typename Predicate>
+int count_if(const TextSrc& t, Predicate pred, int start = Start, int end = End, int step = Step)
 {
     int cnt = 0;
-    --start;
-    while((start = find_if(left_view(t, end), pred, start + 1)) != End)
+    start -= step;
+    while ((start = find_if(t, pred, start + step, end, step)) != End)
         ++cnt;
     return cnt;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int count_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+int count_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step,
+              Case sensitivity = Case::Sensitive)
 {
     int cnt = 0;
-    --start;
-    while((start = find_any(left_view(t, end), d, start + 1)) != End)
+    start -= step;
+    while ((start = find_any(t, d, start + step, end, step, sensitivity)) != End)
         ++cnt;
     return cnt;
 }

--- a/include/text_processing/find.hpp
+++ b/include/text_processing/find.hpp
@@ -3,10 +3,9 @@
 #include "common.hpp"
 
 namespace Text {
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-    requires std::equality_comparable<TextT>
-int find_impl(const TextSrc& t, const NeedleSrc& n, int start, int end, int step)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc> && std::equality_comparable<container_type_t<TextSrc>>
+int find_impl(const TextSrc& t, const NeedleSrc& n, int start, int end, int step, Case sensitivity)
 {
     if (step == 0)
         return End;
@@ -23,7 +22,7 @@ int find_impl(const TextSrc& t, const NeedleSrc& n, int start, int end, int step
     auto current = step < 0 ? text.ptr + end - needle.length : text.ptr + start;
     while (current + needle.length <= text.ptr + end && current >= text.ptr)
     {
-        if (!are_equal(current, needle.ptr, needle.length))
+        if (!are_equal(current, needle.ptr, needle.length, sensitivity))
         {
             current += step;
             continue;
@@ -33,21 +32,23 @@ int find_impl(const TextSrc& t, const NeedleSrc& n, int start, int end, int step
     return End;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int find(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+int find(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step,
+         Case sensitivity = Case::Sensitive)
 {
-    return find_impl(t, n, start, end, step);
+    return find_impl(t, n, start, end, step, sensitivity);
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int rfind(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+int rfind(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step,
+          Case sensitivity = Case::Sensitive)
 {
-    return find_impl(t, n, start, end, -step);
+    return find_impl(t, n, start, end, -step, sensitivity);
 }
 
-template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
+template <typename TextSrc, typename Predicate>
 int find_if_impl(const TextSrc& t, Predicate pred, int start, int end, int step)
 {
     if (step == 0)
@@ -71,27 +72,27 @@ int find_if_impl(const TextSrc& t, Predicate pred, int start, int end, int step)
     return End;
 }
 
-template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
+template <typename TextSrc, typename Predicate>
 int find_if(const TextSrc& t, Predicate pred, int start = Start, int end = End, int step = Step)
 {
     return find_if_impl(t, pred, start, end, step);
 }
 
-template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
+template <typename TextSrc, typename Predicate>
 int rfind_if(const TextSrc& t, Predicate pred, int start = Start, int end = End, int step = Step)
 {
     return find_if_impl(t, pred, start, end, -step);
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int find_any_impl(const TextSrc& t, const NeedleSrc& d, int start, int end, int step)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+int find_any_impl(const TextSrc& t, const NeedleSrc& d, int start, int end, int step, Case sensitivity)
 {
     if (step == 0)
         return End;
 
     Text text(t);
-    Delimiters delimiters(d);
+    Delimiters delimiters(d, sensitivity);
 
     if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
         return End;
@@ -99,7 +100,7 @@ int find_any_impl(const TextSrc& t, const NeedleSrc& d, int start, int end, int 
     auto current = step < 0 ? text.ptr + end - 1 : text.ptr + start;
     while (current < text.ptr + text.length && current >= text.ptr)
     {
-        if (!delimiters.contains(*current))
+        if (!delimiters.contains(*current, sensitivity))
         {
             current += step;
             continue;
@@ -109,18 +110,20 @@ int find_any_impl(const TextSrc& t, const NeedleSrc& d, int start, int end, int 
     return End;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int find_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+int find_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step,
+             Case sensitivity = Case::Sensitive)
 {
-    return find_any_impl(t, d, start, end, step);
+    return find_any_impl(t, d, start, end, step, sensitivity);
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int rfind_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step)
+template <typename TextSrc, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+int rfind_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step,
+              Case sensitivity = Case::Sensitive)
 {
-    return find_any_impl(t, d, start, end, -step);
+    return find_any_impl(t, d, start, end, -step, sensitivity);
 }
 
 } // namespace Text

--- a/include/text_processing/join.hpp
+++ b/include/text_processing/join.hpp
@@ -3,11 +3,11 @@
 #include "common.hpp"
 
 namespace Text {
-template <typename TextSrc, typename DelimSrc, typename TextT = container_type_t<TextSrc>,
-          typename DelimT = container_type_t<DelimSrc>, std::enable_if_t<std::is_same_v<TextT, DelimT>, int> = 0>
+template <typename TextSrc, typename DelimSrc>
+    requires CanBeDelimiterOf<DelimSrc, TextSrc>
 auto join(const std::vector<TextSrc>& views, DelimSrc d)
 {
-    std::basic_string<TextT> result;
+    std::basic_string<container_type_t<TextSrc>> result;
     if (views.empty())
         return result;
 

--- a/include/text_processing/remove.hpp
+++ b/include/text_processing/remove.hpp
@@ -12,128 +12,89 @@ struct RemoveResult
     int operations = 0;
 };
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-auto remove_impl(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End) -> RemoveResult<TextT>
+template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+auto remove_impl(const TextSrc& t, const NeedleSrc& n, int start, int end, int step, Case sensitivity)
+    -> RemoveResult<TextT>
 {
     Text txt(t);
     if (sanitize_index(start, txt.length) == End || sanitize_index(end, txt.length) == End)
         return {std::basic_string(t)};
-    auto splitted = split(t, n, SplitBehavior::KeepEmpty, start, end);
+    auto splitted = split(t, n, SplitBehavior::KeepEmpty, start, end, step, sensitivity);
     return {join(splitted, std::basic_string_view<TextT>{}), static_cast<int>(splitted.size()) - 1};
 }
 
-template <typename TextT, typename NeedleSrc, typename NeedleT = container_type_t<NeedleSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int remove(std::basic_string<TextT>& t, const NeedleSrc& n, int start = 0)
+template <typename TextT, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextT>
+int remove(std::basic_string<TextT>& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step,
+           Case sensitivity = Case::Sensitive)
 {
-    auto result = remove_impl(t, n, start);
+    auto result = remove_impl(t, n, start, end, step, sensitivity);
     t = std::move(result.text);
     return result.operations;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-[[nodiscard]] auto removed(const TextSrc& t, const NeedleSrc& n, int start = 0) -> std::basic_string<TextT>
+template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+[[nodiscard]] auto removed(const TextSrc& t, const NeedleSrc& n, int start = Start, int end = End, int step = Step,
+                           Case sensitivity = Case::Sensitive) -> std::basic_string<TextT>
 {
-    return remove_impl(t, n, start).text;
+    return remove_impl(t, n, start, end, step, sensitivity).text;
 }
 
-template <typename TextT, typename NeedleSrc, typename NeedleT = container_type_t<NeedleSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int rremove(std::basic_string<TextT>& t, const NeedleSrc& n, int start = 0)
-{
-    auto result = remove_impl(t, n, 0, -start - 1);
-    t = std::move(result.text);
-    return result.operations;
-}
-
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-[[nodiscard]] auto rremoved(const TextSrc& t, const NeedleSrc& n, int start = 0) -> std::basic_string<TextT>
-{
-    return remove_impl(t, n, 0, -start - 1).text;
-}
-
-template <typename TextSrc, typename TextT = container_type_t<TextSrc>, typename Predicate>
-auto remove_if_impl(const TextSrc& t, Predicate pred, int start = Start, int end = End) -> RemoveResult<TextT>
+template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
+auto remove_if_impl(const TextSrc& t, Predicate pred, int start = Start, int end = End, int step = Step)
+    -> RemoveResult<TextT>
 {
     Text txt(t);
     if (sanitize_index(start, txt.length) == End || sanitize_index(end, txt.length) == End)
         return {std::basic_string(t)};
-    auto splitted = split_if(t, pred, SplitBehavior::KeepEmpty, start, end);
+    auto splitted = split_if(t, pred, SplitBehavior::KeepEmpty, start, end, step);
     return {join(splitted, std::basic_string_view<TextT>{}), static_cast<int>(splitted.size()) - 1};
 }
 
 template <typename TextT, typename Predicate>
-int remove_if(std::basic_string<TextT>& t, Predicate pred, int start = 0)
+int remove_if(std::basic_string<TextT>& t, Predicate pred, int start = Start, int end = End, int step = Step)
 {
-    auto result = remove_if_impl(t, pred, start);
+    auto result = remove_if_impl(t, pred, start, end, step);
     t = std::move(result.text);
     return result.operations;
 }
 
-template <typename TextSrc, typename TextT = container_type_t<TextSrc>, typename Predicate>
+template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
 [[nodiscard]] auto removed_if(const TextSrc& t, Predicate pred, int start = 0) -> std::basic_string<TextT>
 {
     return remove_if_impl(t, pred, start).text;
 }
 
-template <typename TextT, typename Predicate>
-int rremove_if(std::basic_string<TextT>& t, Predicate pred, int start = 0)
-{
-    auto result = remove_if_impl(t, pred, 0, -start - 1);
-    t = std::move(result.text);
-    return result.operations;
-}
-
-template <typename TextSrc, typename TextT = container_type_t<TextSrc>, typename Predicate>
-[[nodiscard]] auto rremoved_if(const TextSrc& t, Predicate pred, int start = 0) -> std::basic_string<TextT>
-{
-    return remove_if_impl(t, pred, 0, -start - 1).text;
-}
-
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-auto remove_any_impl(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End) -> RemoveResult<TextT>
+template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+auto remove_any_impl(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step,
+                     Case sensitivity = Case::Sensitive) -> RemoveResult<TextT>
 {
     Text txt(t);
     if (sanitize_index(start, txt.length) == End || sanitize_index(end, txt.length) == End)
         return {std::basic_string(t)};
-    auto splitted = split_any(t, d, SplitBehavior::KeepEmpty, start, end);
+    auto splitted = split_any(t, d, SplitBehavior::KeepEmpty, start, end, step, sensitivity);
     return {join(splitted, std::basic_string_view<TextT>{}), static_cast<int>(splitted.size()) - 1};
 }
 
-template <typename TextT, typename NeedleSrc, typename NeedleT = container_type_t<NeedleSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int remove_any(std::basic_string<TextT>& t, const NeedleSrc& d, int start = 0)
+template <typename TextT, typename NeedleSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextT>
+int remove_any(std::basic_string<TextT>& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step,
+               Case sensitivity = Case::Sensitive)
 {
-    auto result = remove_any_impl(t, d, start);
+    auto result = remove_any_impl(t, d, start, end, step, sensitivity);
     t = std::move(result.text);
     return result.operations;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-[[nodiscard]] auto removed_any(const TextSrc& t, const NeedleSrc& d, int start = 0) -> std::basic_string<TextT>
+template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc>
+[[nodiscard]] auto removed_any(const TextSrc& t, const NeedleSrc& d, int start = Start, int end = End, int step = Step,
+                               Case sensitivity = Case::Sensitive) -> std::basic_string<TextT>
 {
-    return remove_any_impl(t, d, start).text;
-}
-
-template <typename TextT, typename NeedleSrc, typename NeedleT = container_type_t<NeedleSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-int rremove_any(std::basic_string<TextT>& t, const NeedleSrc& d, int start = 0)
-{
-    auto result = remove_any_impl(t, d, 0, -start - 1);
-    t = std::move(result.text);
-    return result.operations;
-}
-
-template <typename TextSrc, typename NeedleSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, std::enable_if_t<std::is_same_v<TextT, NeedleT>, int> = 0>
-[[nodiscard]] auto rremoved_any(const TextSrc& t, const NeedleSrc& d, int start = 0) -> std::basic_string<TextT>
-{
-    return remove_any_impl(t, d, 0, -start - 1).text;
+    return remove_any_impl(t, d, start, end, step, sensitivity).text;
 }
 
 } // namespace Text

--- a/include/text_processing/replace.hpp
+++ b/include/text_processing/replace.hpp
@@ -14,93 +14,95 @@ struct ReplaceResult
     int operations = 0;
 };
 
-template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replace_impl(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End)
-    -> ReplaceResult<TextT>
+template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc> &&
+             SameDataType<NeedleSrc, ReplaceSrc>
+             auto replace_impl(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start, int end, int step,
+                               Case sensitivity) -> ReplaceResult<TextT>
 {
     if (sanitize_index(start, t.length()) == End || sanitize_index(end, t.length()) == End)
         return {std::basic_string(t)};
-    auto splitted = split(t, n, SplitBehavior::KeepEmpty, start, end);
+    auto splitted = split(t, n, SplitBehavior::KeepEmpty, start, end, step, sensitivity);
     return {join(splitted, r), static_cast<int>(splitted.size()) - 1};
 }
 
-template <typename TextT, typename NeedleSrc, typename ReplaceSrc, typename NeedleT = container_type_t<NeedleSrc>,
-          typename ReplaceT = container_type_t<ReplaceSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-int replace(std::basic_string<TextT>& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End)
+template <typename TextT, typename NeedleSrc, typename ReplaceSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextT> && SameDataType<NeedleSrc, ReplaceSrc>
+int replace(std::basic_string<TextT>& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End,
+            int step = Step, Case sensivity = Case::Insensitive)
 {
-    auto result = replace_impl(t, n, r, start, end);
+    auto result = replace_impl(t, n, r, start, end, step, sensivity);
     t = std::move(result.text);
     return result.operations;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replaced(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End)
-    -> std::basic_string<TextT>
+template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc> &&
+             SameDataType<NeedleSrc, ReplaceSrc>
+             auto replaced(const TextSrc& t, const NeedleSrc& n, const ReplaceSrc& r, int start = Start, int end = End,
+                           int step = Step, Case sensitivity = Case::Sensitive) -> std::basic_string<TextT>
 {
-    return replace_impl(t, n, r, start, end).text;
+    return replace_impl(t, n, r, start, end, step, sensitivity).text;
 }
 
-template <typename TextSrc, typename Predicate, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
-          typename ReplaceT = container_type_t<ReplaceSrc>, std::enable_if_t<std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replace_if_impl(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End)
+template <typename TextSrc, typename Predicate, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>>
+    requires SameDataType<TextSrc, ReplaceSrc>
+auto replace_if_impl(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start, int end, int step)
     -> ReplaceResult<TextT>
 {
     if (sanitize_index(start, t.length()) == End || sanitize_index(end, t.length()) == End)
         return {std::basic_string(t)};
-    auto splitted = split_if(t, pred, SplitBehavior::KeepEmpty, start, end);
+    auto splitted = split_if(t, pred, SplitBehavior::KeepEmpty, start, end, step);
     return {join(splitted, r), static_cast<int>(splitted.size()) - 1};
 }
 
-template <typename TextT, typename Predicate, typename ReplaceSrc, typename ReplaceT = container_type_t<ReplaceSrc>,
-          std::enable_if_t<std::is_same_v<TextT, ReplaceT>, int> = 0>
-int replace_if(std::basic_string<TextT>& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End)
+template <typename TextT, typename Predicate, typename ReplaceSrc>
+    requires SameDataType<TextT, ReplaceSrc>
+int replace_if(std::basic_string<TextT>& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End,
+               int step = Step)
 {
-    auto result = replace_if_impl(t, pred, r, start, end);
+    auto result = replace_if_impl(t, pred, r, start, end, step);
     t = std::move(result.text);
     return result.operations;
 }
 
-template <typename TextSrc, typename Predicate, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
-          typename ReplaceT = container_type_t<ReplaceSrc>, std::enable_if_t<std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replaced_if(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End)
-    -> std::basic_string<TextT>
+template <typename TextSrc, typename Predicate, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>>
+    requires SameDataType<TextSrc, ReplaceSrc>
+auto replaced_if(const TextSrc& t, Predicate pred, const ReplaceSrc& r, int start = Start, int end = End,
+                 int step = Step) -> std::basic_string<TextT>
 {
-    return replace_if_impl(t, pred, r, start, end).text;
+    return replace_if_impl(t, pred, r, start, end, step).text;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replace_any_impl(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start, int end = End)
-    -> ReplaceResult<TextT>
+template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc> &&
+             SameDataType<NeedleSrc, ReplaceSrc>
+             auto replace_any_impl(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start, int end,
+                                   int step, Case sensitivity) -> ReplaceResult<TextT>
 {
     if (sanitize_index(start, t.length()) == End || sanitize_index(end, t.length()) == End)
         return {std::basic_string(t)};
-    auto splitted = split_any(t, d, SplitBehavior::KeepEmpty, start, end);
+    auto splitted = split_any(t, d, SplitBehavior::KeepEmpty, start, end, step, sensitivity);
     return {join(splitted, r), static_cast<int>(splitted.size()) - 1};
 }
 
-template <typename TextT, typename NeedleSrc, typename ReplaceSrc, typename NeedleT = container_type_t<NeedleSrc>,
-          typename ReplaceT = container_type_t<ReplaceSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-int replace_any(std::basic_string<TextT>& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start, int end = End)
+template <typename TextT, typename NeedleSrc, typename ReplaceSrc>
+    requires CanBeDelimiterOf<NeedleSrc, TextT> && SameDataType<NeedleSrc, ReplaceSrc>
+int replace_any(std::basic_string<TextT>& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start, int end = End,
+                int step = Step, Case sensitivity = Case::Sensitive)
 {
-    auto result = replace_any_impl(t, d, r, start, end);
+    auto result = replace_any_impl(t, d, r, start, end, step, sensitivity);
     t = std::move(result.text);
     return result.operations;
 }
 
-template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>,
-          typename NeedleT = container_type_t<NeedleSrc>, typename ReplaceT = container_type_t<ReplaceSrc>,
-          std::enable_if_t<std::is_same_v<TextT, NeedleT> && std::is_same_v<TextT, ReplaceT>, int> = 0>
-auto replaced_any(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start, int end = End)
-    -> std::basic_string<TextT>
+template <typename TextSrc, typename NeedleSrc, typename ReplaceSrc, typename TextT = container_type_t<TextSrc>>
+    requires CanBeDelimiterOf<NeedleSrc, TextSrc> &&
+             SameDataType<NeedleSrc, ReplaceSrc>
+             auto replaced_any(const TextSrc& t, const NeedleSrc& d, const ReplaceSrc& r, int start = Start,
+                               int end = End, int step = Step, Case sensitivity = Case::Sensitive)
+                 -> std::basic_string<TextT>
 {
-    return replace_any_impl(t, d, r, start, end).text;
+    return replace_any_impl(t, d, r, start, end, step, sensitivity).text;
 }
 } // namespace Text

--- a/include/text_processing/split.hpp
+++ b/include/text_processing/split.hpp
@@ -10,62 +10,68 @@ enum class SplitBehavior
     DropEmpty
 };
 
-template <typename TextSrc, typename DelimSrc, typename TextT = container_type_t<TextSrc>,
-          typename DelimT = container_type_t<DelimSrc>, std::enable_if_t<std::is_same_v<TextT, DelimT>, int> = 0>
-auto split(const TextSrc& t, const DelimSrc& d, SplitBehavior beh = SplitBehavior::KeepEmpty, int start = 0,
-           int end = -1)
+template <typename TextSrc, typename DelimSrc>
+    requires CanBeDelimiterOf<DelimSrc, TextSrc>
+auto split(const TextSrc& t, const DelimSrc& d, SplitBehavior beh = SplitBehavior::KeepEmpty, int start = Start,
+           int end = End, int step = Step, Case sensitivity = Case::Sensitive)
 {
     Text text(t);
     Delimiter delimiter(d);
-    std::vector<std::basic_string_view<TextT>> results;
+    std::vector<std::basic_string_view<container_type_t<TextSrc>>> results;
 
-    if (text.length == 0)
+    if (text.length == 0 || step <= 0)
         return results;
+    auto unsigned_step = static_cast<unsigned int>(step);
+
+    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
+    {
+        results.emplace_back(text.ptr, text.length);
+        return results;
+    }
 
     if (delimiter.length == 0)
     {
-        results.reserve(text.length);
-        for (size_t idx = 0; idx < text.length; ++idx)
-            results.emplace_back(text.ptr + idx, 1);
-        return results;
-    }
-
-    if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
-    {
-        results.emplace_back(text.ptr, text.length);
+        results.reserve((text.length + unsigned_step - 1) / unsigned_step);
+        for (; start < end; start += step)
+            results.emplace_back(text.ptr + start, std::min(end - start, step));
         return results;
     }
 
     auto start_ptr = text.ptr;
-    auto current = text.ptr + start;
+    auto current = start_ptr + start;
+    auto skip_after_match = unsigned_step;
+    while (skip_after_match < delimiter.length)
+        skip_after_match += unsigned_step;
 
-    while (current + delimiter.length <= text.ptr + end + 1)
+    while (current + delimiter.length <= text.ptr + end)
     {
-        if (!are_equal(current, delimiter.ptr, delimiter.length))
+        if (!are_equal(current, delimiter.ptr, delimiter.length, sensitivity))
         {
-            ++current;
+            current += step;
             continue;
         }
         if (start_ptr != current || beh == SplitBehavior::KeepEmpty)
             results.emplace_back(start_ptr, current - start_ptr);
-        current += std::max(delimiter.length, size_t{1});
-        start_ptr = current;
+        start_ptr = current + delimiter.length;
+        current += skip_after_match;
     }
+    current = std::min(current, text.ptr + end);
+    start_ptr = std::min(start_ptr, text.ptr + end);
     if (start_ptr != current || beh == SplitBehavior::KeepEmpty)
         results.emplace_back(start_ptr, text.ptr + text.length - start_ptr);
     return results;
 }
 
-template <typename TextSrc, typename DelimSrc, typename TextT = container_type_t<TextSrc>,
-          typename DelimT = container_type_t<DelimSrc>, std::enable_if_t<std::is_same_v<TextT, DelimT>, int> = 0>
-auto split_any(const TextSrc& t, const DelimSrc& d, SplitBehavior beh = SplitBehavior::KeepEmpty, int start = 0,
-               int end = -1)
+template <typename TextSrc, typename DelimSrc>
+    requires CanBeDelimiterOf<DelimSrc, TextSrc>
+auto split_any(const TextSrc& t, const DelimSrc& d, SplitBehavior beh = SplitBehavior::KeepEmpty, int start = Start,
+               int end = End, int step = Step, Case sensitivity = Case::Sensitive)
 {
     Text text(t);
-    Delimiters delimiters(d);
-    std::vector<std::basic_string_view<TextT>> results;
+    Delimiters delimiters(d, sensitivity);
+    std::vector<std::basic_string_view<container_type_t<TextSrc>>> results;
 
-    if (text.length == 0)
+    if (text.length == 0 || step <= 0)
         return results;
 
     if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
@@ -75,33 +81,35 @@ auto split_any(const TextSrc& t, const DelimSrc& d, SplitBehavior beh = SplitBeh
     }
 
     auto start_ptr = text.ptr;
-    auto current = text.ptr + start;
+    auto current = start_ptr + start;
 
-    while (current <= text.ptr + end)
+    while (current < text.ptr + end)
     {
-        if (!delimiters.contains(*current))
+        if (!delimiters.contains(*current, sensitivity))
         {
-            ++current;
+            current += step;
             continue;
         }
         if (start_ptr != current || beh == SplitBehavior::KeepEmpty)
             results.emplace_back(start_ptr, current - start_ptr);
-        ++current;
-        start_ptr = current;
+        start_ptr = current + 1;
+        current += step;
     }
+    current = std::min(current, text.ptr + end);
+    start_ptr = std::min(start_ptr, text.ptr + end);
     if (start_ptr != current || beh == SplitBehavior::KeepEmpty)
         results.emplace_back(start_ptr, text.ptr + text.length - start_ptr);
     return results;
 }
 
-template <typename TextSrc, typename Predicate, typename TextT = container_type_t<TextSrc>>
-auto split_if(const TextSrc& t, Predicate pred, SplitBehavior beh = SplitBehavior::KeepEmpty, int start = 0,
-              int end = -1)
+template <typename TextSrc, typename Predicate>
+auto split_if(const TextSrc& t, Predicate pred, SplitBehavior beh = SplitBehavior::KeepEmpty, int start = Start,
+              int end = End, int step = Step)
 {
     Text text(t);
-    std::vector<std::basic_string_view<TextT>> results;
+    std::vector<std::basic_string_view<container_type_t<TextSrc>>> results;
 
-    if (text.length == 0)
+    if (text.length == 0 || step <= 0)
         return results;
 
     if (sanitize_index(start, text.length) == End || sanitize_index(end, text.length) == End)
@@ -111,20 +119,22 @@ auto split_if(const TextSrc& t, Predicate pred, SplitBehavior beh = SplitBehavio
     }
 
     auto start_ptr = text.ptr;
-    auto current = text.ptr + start;
+    auto current = start_ptr + start;
 
     while (current < text.ptr + end)
     {
         if (!pred(*current))
         {
-            ++current;
+            current += step;
             continue;
         }
         if (start_ptr != current || beh == SplitBehavior::KeepEmpty)
             results.emplace_back(start_ptr, current - start_ptr);
-        ++current;
-        start_ptr = current;
+        start_ptr = current + 1;
+        current += step;
     }
+    current = std::min(current, text.ptr + end);
+    start_ptr = std::min(start_ptr, text.ptr + end);
     if (start_ptr != current || beh == SplitBehavior::KeepEmpty)
         results.emplace_back(start_ptr, text.ptr + text.length - start_ptr);
     return results;

--- a/remove.cc
+++ b/remove.cc
@@ -65,6 +65,24 @@ TEST(Remove, SimpleWithViewsAndStartNegative)
     EXPECT_EQ(simple, "simple string withwords"s);
 }
 
+TEST(Remove, CaseInsensitive)
+{
+    using namespace std::literals;
+    std::string simple("simple String with words");
+    auto result = Text::remove(simple, "s"sv, Text::Start, Text::End, Text::Step, Text::Case::Insensitive);
+    EXPECT_EQ(result, 3);
+    EXPECT_EQ(simple, "imple tring with word"s);
+}
+
+TEST(Remove, WithSteps)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result = Text::remove(simple, "s"sv, 1, Text::End, 2);
+    EXPECT_EQ(result, 2);
+    EXPECT_EQ(simple, "simple tring with word"s);
+}
+
 TEST(RemoveIf, ConstVersion)
 {
     using namespace std::literals;
@@ -91,69 +109,6 @@ TEST(RemoveIf, OutOfBoundsStart)
     std::string simple("simple string with words");
     auto result = Text::remove_if(simple, [](auto ch) { return ch > 'u'; }, 100);
     EXPECT_EQ(result, 0);
-    EXPECT_EQ(simple, "simple string with words");
-}
-
-TEST(RRemove, SimpleWithViews)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove(simple, " "sv);
-    EXPECT_EQ(result, 3);
-    EXPECT_EQ(simple, "simplestringwithwords"s);
-}
-
-TEST(RRemove, ConstVersion)
-{
-    using namespace std::literals;
-    std::string_view simple("simple string with words");
-    auto result = Text::rremoved(simple, " "sv);
-    EXPECT_EQ(result, "simplestringwithwords"s);
-    EXPECT_EQ(simple, "simple string with words"s);
-}
-
-TEST(RRemove, SimpleWithViewsAndStart)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove(simple, " "sv, 7);
-    EXPECT_EQ(result, 2);
-    EXPECT_EQ(simple, "simplestringwith words"s);
-}
-
-TEST(RRemove, SimpleWithViewsAndStartNegative)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove(simple, " "sv, -7);
-    EXPECT_EQ(result, 1);
-    EXPECT_EQ(simple, "simplestring with words"s);
-}
-
-TEST(RRemove, OutOfBoundsStart)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove(simple, " "sv, 100);
-    EXPECT_EQ(result, 0);
-    EXPECT_EQ(simple, "simple string with words");
-}
-
-TEST(RRemoveIf, SimpleWithViews)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove_if(simple, [](auto ch) { return ch > 'u'; });
-    EXPECT_EQ(result, 2);
-    EXPECT_EQ(simple, "simple string ith ords");
-}
-
-TEST(RRemoveIf, ConstVersion)
-{
-    using namespace std::literals;
-    std::string_view simple("simple string with words");
-    auto result = Text::rremoved_if(simple, [](auto ch) { return ch > 'u'; });
-    EXPECT_EQ(result, "simple string ith ords");
     EXPECT_EQ(simple, "simple string with words");
 }
 
@@ -202,47 +157,14 @@ TEST(RemoveAny, ConstVersion)
     EXPECT_EQ(simple, "simple string with words");
 }
 
-TEST(RRemoveAny, SimpleWithViews)
+TEST(RemoveAny, CaseInsensitive)
 {
     using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove_any(simple, "tg"sv);
-    EXPECT_EQ(result, 3);
-    EXPECT_EQ(simple, "simple srin wih words"s);
+    std::string simple("simple String With words");
+    auto result = Text::remove_any(simple, "Sw"sv, Text::Start, Text::End, Text::Step, Text::Case::Insensitive);
+    EXPECT_EQ(result, 5);
+    EXPECT_EQ(simple, "imple tring ith ord");
 }
 
-TEST(RRemoveAny, SimpleWithViewsAndStart)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove_any(simple, "tg"sv, 9);
-    EXPECT_EQ(result, 2);
-    EXPECT_EQ(simple, "simple srin with words"s);
-}
 
-TEST(RRemoveAny, OutOfBoundsStart)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove_any(simple, "tg"sv, 100);
-    EXPECT_EQ(result, 0);
-    EXPECT_EQ(simple, "simple string with words");
-}
-
-TEST(RRemoveAny, SimpleWithViewsAndStartNegative)
-{
-    using namespace std::literals;
-    std::string simple("simple string with words");
-    auto result = Text::rremove_any(simple, "tg"sv, -9);
-    EXPECT_EQ(result, 1);
-    EXPECT_EQ(simple, "simple sring with words"s);
-}
-
-TEST(RRemoveAny, ConstVersion)
-{
-    using namespace std::literals;
-    std::string_view simple("simple string with words");
-    auto result = Text::rremoved_any(simple, "tg"sv);
-    EXPECT_EQ(result, "simple srin wih words"s);
-    EXPECT_EQ(simple, "simple string with words");
-}
+//Add steps for replace/split

--- a/replace.cc
+++ b/replace.cc
@@ -47,6 +47,24 @@ TEST(Replace, SimpleWithViewsAndStart)
     EXPECT_EQ(simple, "simple string_with_words"s);
 }
 
+TEST(Replace, CaseInsensitive)
+{
+    using namespace std::literals;
+    std::string simple("simple String with words");
+    auto result = Text::replace(simple, "s"sv, "_"sv, Text::Start, Text::End, Text::Step, Text::Case::Insensitive);
+    EXPECT_EQ(result, 3);
+    EXPECT_EQ(simple, "_imple _tring with word_"s);
+}
+
+TEST(Replace, WithSteps)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result = Text::replace(simple, "s"sv, "_"sv, 1, Text::End, 2);
+    EXPECT_EQ(result, 2);
+    EXPECT_EQ(simple, "simple _tring with word_"s);
+}
+
 TEST(ReplaceIf, ValueLargerThan)
 {
     using namespace std::literals;
@@ -77,6 +95,16 @@ TEST(ReplaceIf, OutOfBoundsStart)
     EXPECT_EQ(simple, "simple string with words");
 }
 
+TEST(ReplaceIf, WithSteps)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result = Text::replace_if(
+        simple, [](auto ch) { return ch > 'u'; }, "_"sv, Text::Start, Text::End, 2);
+    EXPECT_EQ(result, 1);
+    EXPECT_EQ(simple, "simple string _ith words"s);
+}
+
 TEST(ReplaceAny, ValueLargerThan)
 {
     using namespace std::literals;
@@ -102,4 +130,13 @@ TEST(ReplaceAny, OutOfBoundsStart)
     auto result = Text::replace_any(simple, "tg"sv, "_"sv, 100);
     EXPECT_EQ(result, 0);
     EXPECT_EQ(simple, "simple string with words");
+}
+
+TEST(ReplaceAny, WithSteps)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result = Text::replace_any(simple, "sw"sv, "_"sv, 1, Text::End, 2);
+    EXPECT_EQ(result, 3);
+    EXPECT_EQ(simple, "simple _tring with _ord_"s);
 }

--- a/split.cc
+++ b/split.cc
@@ -150,6 +150,50 @@ TEST(Split, LongDelimiter)
     EXPECT_EQ(result_keep, expected);
 }
 
+TEST(Split, Blocks)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result_keep = Text::split(simple, "", Text::SplitBehavior::KeepEmpty, Text::Start, Text::End, 5);
+    auto expected = std::vector<std::string_view>{"simpl"sv, "e str"sv, "ing w"sv, "ith w"sv, "ords"sv};
+    EXPECT_EQ(result_keep, expected);
+}
+
+TEST(Split, CaseSensitivity)
+{
+    using namespace std::literals;
+    std::string simple("simple String with words");
+    auto result_keep = Text::split(simple, "s", Text::SplitBehavior::KeepEmpty, Text::Start, Text::End, Text::Step,
+                                   Text::Case::Insensitive);
+    auto result_drop = Text::split(simple, "s", Text::SplitBehavior::DropEmpty, Text::Start, Text::End, Text::Step,
+                                   Text::Case::Insensitive);
+    auto expected_keep = std::vector<std::string_view>{""sv, "imple "sv, "tring with word"sv, ""sv};
+    auto expected_drop = std::vector<std::string_view>{"imple "sv, "tring with word"sv};
+    EXPECT_EQ(result_keep, expected_keep);
+    EXPECT_EQ(result_drop, expected_drop);
+}
+
+TEST(Split, WithSteps)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result_keep = Text::split(simple, "s", Text::SplitBehavior::KeepEmpty, 1, Text::End, 2);
+    auto result_drop = Text::split(simple, "s", Text::SplitBehavior::DropEmpty, 1, Text::End, 2);
+    auto expected_keep = std::vector<std::string_view>{"simple "sv, "tring with word"sv, ""sv};
+    auto expected_drop = std::vector<std::string_view>{"simple "sv, "tring with word"sv};
+    EXPECT_EQ(result_keep, expected_keep);
+    EXPECT_EQ(result_drop, expected_drop);
+}
+
+TEST(Split, IntVector)
+{
+    std::vector<int> data{1, 2, 3, 1, 1, 2, 3, 1, 4, 1};
+    auto result_keep = Text::split(data, 1, Text::SplitBehavior::KeepEmpty);
+    auto result_drop = Text::split(data, 1, Text::SplitBehavior::DropEmpty);
+    EXPECT_EQ(result_keep.size(), 3 + 3);
+    EXPECT_EQ(result_drop.size(), 3);
+}
+
 TEST(SplitIf, ValueLargerThan)
 {
     using namespace std::literals;
@@ -176,6 +220,16 @@ TEST(SplitIf, OutOfBoundsStart)
     auto result = Text::split_if(
         simple_sv, [](auto ch) { return ch > 'u'; }, Text::SplitBehavior::KeepEmpty, 100);
     EXPECT_EQ(result.size(), 1);
+}
+
+TEST(SplitIf, WithSteps)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result_keep = Text::split_if(
+        simple, [](auto ch) { return ch > 'u'; }, Text::SplitBehavior::KeepEmpty, 1, Text::End, 2);
+    auto expected = std::vector<std::string_view>{"simple string with "sv, "ords"sv};
+    EXPECT_EQ(result_keep, expected);
 }
 
 TEST(SplitAny, SimpleWithView)
@@ -254,11 +308,28 @@ TEST(SplitAny, MultipleDelimiters)
     EXPECT_EQ(result_drop.size(), 7);
 }
 
-TEST(Split, IntVector)
+TEST(SplitAny, CaseSensitivity)
 {
-    std::vector<int> data{1, 2, 3, 1, 1, 2, 3, 1, 4, 1};
-    auto result_keep = Text::split(data, 1, Text::SplitBehavior::KeepEmpty);
-    auto result_drop = Text::split(data, 1, Text::SplitBehavior::DropEmpty);
-    EXPECT_EQ(result_keep.size(), 3 + 3);
-    EXPECT_EQ(result_drop.size(), 3);
+    using namespace std::literals;
+    std::string simple("simple String with words");
+    auto result_keep = Text::split_any(simple, "Sw", Text::SplitBehavior::KeepEmpty, Text::Start, Text::End, Text::Step,
+                                       Text::Case::Insensitive);
+    auto result_drop = Text::split_any(simple, "Sw", Text::SplitBehavior::DropEmpty, Text::Start, Text::End, Text::Step,
+                                       Text::Case::Insensitive);
+    auto expected_keep = std::vector<std::string_view>{""sv, "imple "sv, "tring "sv, "ith "sv, "ord"sv, ""sv};
+    auto expected_drop = std::vector<std::string_view>{"imple "sv, "tring "sv, "ith "sv, "ord"sv};
+    EXPECT_EQ(result_keep, expected_keep);
+    EXPECT_EQ(result_drop, expected_drop);
+}
+
+TEST(SplitAny, WithSteps)
+{
+    using namespace std::literals;
+    std::string simple("simple string with words");
+    auto result_keep = Text::split_any(simple, "s", Text::SplitBehavior::KeepEmpty, 1, Text::End, 2);
+    auto result_drop = Text::split_any(simple, "s", Text::SplitBehavior::DropEmpty, 1, Text::End, 2);
+    auto expected_keep = std::vector<std::string_view>{"simple "sv, "tring with word"sv, ""sv};
+    auto expected_drop = std::vector<std::string_view>{"simple "sv, "tring with word"sv};
+    EXPECT_EQ(result_keep, expected_keep);
+    EXPECT_EQ(result_drop, expected_drop);
 }


### PR DESCRIPTION
* Introducing step value to all of algorithms make their API more coherent
* Case insensitive comparison will work by default but it might result in the same output as case sensitive one. If any type should behave differently specialize `Text::detail::caseless(const T&)` template.